### PR TITLE
I only changed init.lua so it requires plugins first and then keymaps.

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -21,9 +21,9 @@ vim.opt.expandtab   = true
 vim.opt.autowrite   = false
 vim.opt.formatoptions = ''
 
-require("core.keymaps")
 --require("core.dvorak")	-- delete this line if you don't like using DVORAK
 require("core.plugins")
+require("core.keymaps")
 require("core.gui")
 -- disable some useless standard plugins to save startup time
 -- these features have been better covered by plugins


### PR DESCRIPTION
If you requires keymaps first there are configs related to plugins which they can't recognize first if they are trying this great neovim config for the first time, neovim shows an error saying PackerSync is not recongnized.